### PR TITLE
Add x-transfer GET endpoint implementing all scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
-    "@paraspell/sdk": "^1.1.13",
+    "@paraspell/sdk": "^2.0.4",
     "@polkadot/api": "^10.9.1",
     "@polkadot/api-base": "^10.9.1",
     "@polkadot/apps-config": "^0.124.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
   '@paraspell/sdk':
-    specifier: ^1.1.13
-    version: 1.1.13(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1)
+    specifier: ^2.0.4
+    version: 2.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1)
   '@polkadot/api':
     specifier: ^10.9.1
     version: 10.9.1
@@ -1518,8 +1518,8 @@ packages:
       '@open-web3/orml-type-definitions': 1.1.4
     dev: false
 
-  /@paraspell/sdk@1.1.13(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1):
-    resolution: {integrity: sha512-/Bqv13nmufTATv5rUJBGRLzT2YeQhkw3G997+NKoeLCIzNAUOMKCV6dE0D1CrJtSv4B4I6YxhVZdxvuJWD1IeQ==}
+  /@paraspell/sdk@2.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1):
+    resolution: {integrity: sha512-AEWo4ju59OeGjz022kA+yaDSbWIIQL1x/o7TTplo32zQmp6T3sX/kRWn/DXfu0P7cfuILyOsTbdPBUfIJ8RgPA==}
     peerDependencies:
       '@polkadot/api': ^10.6.1
       '@polkadot/api-base': ^10.6.1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { XTransferModule } from './x-transfer/x-transfer.module';
 
 @Module({
-  imports: [],
+  imports: [XTransferModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/x-transfer/dto/XTransferDto.ts
+++ b/src/x-transfer/dto/XTransferDto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsNumberString } from 'class-validator';
+
+export class XTransferDto {
+  from: string;
+  to: string;
+
+  @IsNotEmpty()
+  @IsNumberString()
+  amount: number;
+
+  @IsNotEmpty()
+  address: string;
+
+  currency: string;
+}

--- a/src/x-transfer/x-transfer.controller.spec.ts
+++ b/src/x-transfer/x-transfer.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { XTransferController } from './x-transfer.controller';
+import { XTransferService } from './x-transfer.service';
+
+describe('XTransferController', () => {
+  let controller: XTransferController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [XTransferController],
+      providers: [XTransferService],
+    }).compile();
+
+    controller = module.get<XTransferController>(XTransferController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/x-transfer/x-transfer.controller.ts
+++ b/src/x-transfer/x-transfer.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { XTransferService } from './x-transfer.service';
+import { XTransferDto } from './dto/XTransferDto';
+
+@Controller('x-transfer')
+export class XTransferController {
+  constructor(private readonly xTransferService: XTransferService) {}
+
+  @Get()
+  generateXcmCall(@Query() queryParams: XTransferDto) {
+    return this.xTransferService.generateXcmCall(queryParams);
+  }
+}

--- a/src/x-transfer/x-transfer.module.ts
+++ b/src/x-transfer/x-transfer.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { XTransferService } from './x-transfer.service';
+import { XTransferController } from './x-transfer.controller';
+
+@Module({
+  controllers: [XTransferController],
+  providers: [XTransferService],
+})
+export class XTransferModule {}

--- a/src/x-transfer/x-transfer.service.spec.ts
+++ b/src/x-transfer/x-transfer.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { XTransferService } from './x-transfer.service';
+
+describe('XTransferService', () => {
+  let service: XTransferService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [XTransferService],
+    }).compile();
+
+    service = module.get<XTransferService>(XTransferService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/x-transfer/x-transfer.service.ts
+++ b/src/x-transfer/x-transfer.service.ts
@@ -1,0 +1,106 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import {
+  Builder,
+  IncompatibleNodesError,
+  InvalidCurrencyError,
+  NODE_NAMES,
+  TNode,
+  TSerializedApiCall,
+  getNodeEndpointOption,
+  getRelayChainSymbol,
+} from '@paraspell/sdk';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { XTransferDto } from './dto/XTransferDto';
+
+const getNodeRelayChainWsUrl = (destinationNode: TNode) => {
+  const symbol = getRelayChainSymbol(destinationNode);
+  const POLKADOT_WS = 'wss://kusama-rpc.polkadot.io';
+  const KUSAMA_WS = 'wss://rpc.polkadot.io';
+  return symbol === 'DOT' ? POLKADOT_WS : KUSAMA_WS;
+};
+
+const findWsUrlByNode = (node: TNode) => {
+  const nodeInfo = getNodeEndpointOption(node);
+  const providers = Object.values(nodeInfo.providers);
+
+  if (providers.length < 1) {
+    throw new InternalServerErrorException(
+      `We couldn't find any WS url for node ${node}. Check your @polkadot/apps-config dependency version or open an issue here https://github.com/paraspell/xcm-api`,
+    );
+  }
+
+  return providers[0];
+};
+
+const determineWsUrl = (fromNode?: TNode, destinationNode?: TNode) => {
+  return fromNode
+    ? findWsUrlByNode(fromNode)
+    : getNodeRelayChainWsUrl(destinationNode);
+};
+
+@Injectable()
+export class XTransferService {
+  async generateXcmCall({ from, to, amount, address, currency }: XTransferDto) {
+    if (!from && !to) {
+      throw new BadRequestException(
+        "You need to provide either 'from' or 'to' query parameters",
+      );
+    }
+
+    if (from && !NODE_NAMES.includes(from as TNode)) {
+      throw new BadRequestException(
+        `Node ${from} is not valid. Check docs for valid nodes.`,
+      );
+    }
+
+    if (to && !NODE_NAMES.includes(to as TNode)) {
+      throw new BadRequestException(
+        `Node ${to} is not valid. Check docs for valid nodes.`,
+      );
+    }
+
+    if (from && to && !currency) {
+      throw new BadRequestException(`Currency should not be empty.`);
+    }
+
+    const wsUrl = determineWsUrl(from as TNode, to as TNode);
+    const wsProvider = new WsProvider(wsUrl);
+    const api = await ApiPromise.create({ provider: wsProvider });
+
+    let builder: any = Builder(api);
+
+    if (from && to) {
+      // Parachain to parachain
+      builder = builder
+        .from(from as TNode)
+        .to(to as TNode)
+        .currency(currency);
+    } else if (from) {
+      // Parachain to relaychain
+      builder = builder.from(from as TNode);
+    } else if (to) {
+      // Relaychain to parachain
+      builder = builder.to(to as TNode);
+    }
+
+    builder = builder.amount(amount).address(address);
+
+    let response: TSerializedApiCall;
+    try {
+      response = builder.buildSerializedApiCall();
+    } catch (e) {
+      if (
+        e instanceof InvalidCurrencyError ||
+        e instanceof IncompatibleNodesError
+      ) {
+        throw new BadRequestException(e.message);
+      }
+      throw new InternalServerErrorException(e.message);
+    }
+    return response;
+  }
+}


### PR DESCRIPTION
## Changes

This pull request adds an X-transfer endpoint to the existing LightSpell✨ API, which utilizes the XCM-SDK to facilitate fast XCM (Cross-Consensus Message) calls. The X-transfer endpoint supports three scenarios: ParaToPara, RelayToPara, and ParaToRelay.

The code changes include the following files:

1. `x-transfer.dto.ts`: This file defines the data transfer object (DTO) for the XTransfer endpoint. It includes properties such as `from`, `to`, `amount`, `address`, and `currency`.

2. `x-transfer.controller.ts`: This file implements the XTransferController, which handles incoming requests to the X-transfer endpoint. It utilizes the XTransferService to generate XCM calls based on the provided query parameters.

3. `x-transfer.module.ts`: This file defines the XTransferModule, which is responsible for managing the XTransferController and XTransferService.

4. `x-transfer.service.ts`: This file implements the XTransferService, which generates XCM calls based on the provided query parameters. It interacts with the XCM-SDK, @paraspell/sdk, and the Polkadot API to build and execute the XCM calls.

These changes enable users to make XCM calls for transferring assets between parachains and relaychains, supporting different currency types. The XCM calls are generated based on the provided query parameters and adhere to the ParaToPara, RelayToPara, and ParaToRelay scenarios.

## Query parameters

The X-transfer endpoint supports the following query parameters:

1. `from` (optional): Specifies the source node for the transfer. It represents the parachain from which the assets will be transferred. Valid values include the names of supported nodes.

2. `to` (optional): Specifies the destination node for the transfer. It represents the parachain to which the assets will be transferred. Valid values include the names of supported nodes.

3. `amount`: Specifies the amount of assets to transfer. It should be a numeric value.

4. `address`: Specifies the address of the recipient or sender of the assets. It should be a valid address format.

5. `currency`: Specifies the currency type of the assets being transferred. It represents the token or asset being sent. It should be a string value.

The presence of the `from` and `to` parameters determines the type of transfer scenario:

- If both `from` and `to` parameters are provided, it indicates a ParaToPara scenario, where assets are transferred between two parachains.

- If only the `from` parameter is provided, it indicates a ParaToRelay scenario, where assets are transferred from a parachain to a relaychain.

- If only the `to` parameter is provided, it indicates a RelayToPara scenario, where assets are transferred from a relaychain to a parachain.

## Example call

Example call using popular JavaScript library Axios:
```
import axios from "axios";

const options = {
  method: 'GET',
  url: 'http://localhost:3001/x-transfer',
  params: {
    to: 'Statemint',
    address: '5F5586mfsnM6durWRLptYt3jSUs55KEmahdodQ5tQMr9iY96',
    currency: 'DOT',
    amount: '1000000000'
  }
};

axios.request(options).then(function (response) {
  console.log(response.data);
}).catch(function (error) {
  console.error(error);
});
```

Overall, this pull request enhances the LightSpell✨ API by adding the X-transfer functionality, expanding its capabilities to support 44 parachains.