### PR TITLE
Add endpoints for HRMP pallet (Opening and closing channels)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@nestjs/core": "^10.0.0",
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
-    "@paraspell/sdk": "^2.0.4",
+    "@paraspell/sdk": "^2.0.5",
     "@polkadot/api": "^10.9.1",
     "@polkadot/api-base": "^10.9.1",
     "@polkadot/apps-config": "^0.124.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ dependencies:
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
   '@paraspell/sdk':
-    specifier: ^2.0.4
-    version: 2.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1)
+    specifier: ^2.0.5
+    version: 2.0.5(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1)
   '@polkadot/api':
     specifier: ^10.9.1
     version: 10.9.1
@@ -1518,8 +1518,8 @@ packages:
       '@open-web3/orml-type-definitions': 1.1.4
     dev: false
 
-  /@paraspell/sdk@2.0.4(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1):
-    resolution: {integrity: sha512-AEWo4ju59OeGjz022kA+yaDSbWIIQL1x/o7TTplo32zQmp6T3sX/kRWn/DXfu0P7cfuILyOsTbdPBUfIJ8RgPA==}
+  /@paraspell/sdk@2.0.5(@polkadot/api-base@10.9.1)(@polkadot/api@10.9.1)(@polkadot/apps-config@0.124.1)(@polkadot/types@10.9.1):
+    resolution: {integrity: sha512-OBe4A5fTFMlNz9zkr/WqWlEloFF92PWQmJvJvbjKemfPOGkXlsGRNZjNR5sNy+zdxEboUKSQdgFRdV8OLz2tqg==}
     peerDependencies:
       '@polkadot/api': ^10.6.1
       '@polkadot/api-base': ^10.6.1

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,9 +3,10 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { XTransferModule } from './x-transfer/x-transfer.module';
 import { AssetsModule } from './assets/assets.module';
+import { ChannelsModule } from './channels/channels.module';
 
 @Module({
-  imports: [XTransferModule, AssetsModule],
+  imports: [XTransferModule, AssetsModule, ChannelsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChannelsController } from './channels.controller';
+import { ChannelsService } from './channels.service';
+
+describe('ChannelsController', () => {
+  let controller: ChannelsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ChannelsController],
+      providers: [ChannelsService],
+    }).compile();
+
+    controller = module.get<ChannelsController>(ChannelsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Delete, Query } from '@nestjs/common';
+import { ChannelsService } from './channels.service';
+import { OpenChannelDto } from './dto/open-channel.dto';
+import { CloseChannelDto } from './dto/close-channel.dto';
+
+@Controller('hrmp/channels')
+export class ChannelsController {
+  constructor(private readonly channelsService: ChannelsService) {}
+
+  @Post()
+  openChannel(@Query() openChannelDto: OpenChannelDto) {
+    return this.channelsService.openChannel(openChannelDto);
+  }
+
+  @Delete()
+  closeChannel(@Query() closeChannelDto: CloseChannelDto) {
+    return this.channelsService.closeChannel(closeChannelDto);
+  }
+}

--- a/src/channels/channels.module.ts
+++ b/src/channels/channels.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ChannelsService } from './channels.service';
+import { ChannelsController } from './channels.controller';
+
+@Module({
+  controllers: [ChannelsController],
+  providers: [ChannelsService],
+})
+export class ChannelsModule {}

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChannelsService } from './channels.service';
+
+describe('ChannelsService', () => {
+  let service: ChannelsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChannelsService],
+    }).compile();
+
+    service = module.get<ChannelsService>(ChannelsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -1,0 +1,44 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { OpenChannelDto } from './dto/open-channel.dto';
+import { CloseChannelDto } from './dto/close-channel.dto';
+import { Builder, NODE_NAMES, TNode } from '@paraspell/sdk';
+
+@Injectable()
+export class ChannelsService {
+  async openChannel({ from, to, maxSize, maxMessageSize }: OpenChannelDto) {
+    if (!NODE_NAMES.includes(from as TNode)) {
+      throw new BadRequestException(
+        `From node ${from} is not valid. Check docs for valid nodes.`,
+      );
+    }
+
+    if (!NODE_NAMES.includes(to as TNode)) {
+      throw new BadRequestException(
+        `To node ${to} is not valid. Check docs for valid nodes.`,
+      );
+    }
+
+    return Builder(null)
+      .from(from as TNode)
+      .to(to as TNode)
+      .openChannel()
+      .maxSize(Number(maxSize))
+      .maxMessageSize(Number(maxMessageSize))
+      .buildSerializedApiCall();
+  }
+
+  async closeChannel({ from, inbound, outbound }: CloseChannelDto) {
+    if (!NODE_NAMES.includes(from as TNode)) {
+      throw new BadRequestException(
+        `From node ${from} is not valid. Check docs for valid nodes.`,
+      );
+    }
+
+    return Builder(null)
+      .from(from as TNode)
+      .closeChannel()
+      .inbound(Number(inbound))
+      .outbound(Number(outbound))
+      .buildSerializedApiCall();
+  }
+}

--- a/src/channels/dto/close-channel.dto.ts
+++ b/src/channels/dto/close-channel.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsNumberString, IsString } from 'class-validator';
+
+export class CloseChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  from: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  inbound: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  outbound: string;
+}

--- a/src/channels/dto/open-channel.dto.ts
+++ b/src/channels/dto/open-channel.dto.ts
@@ -1,0 +1,19 @@
+import { IsNotEmpty, IsNumberString, IsString } from 'class-validator';
+
+export class OpenChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  from: string;
+
+  @IsString()
+  @IsNotEmpty()
+  to: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  maxSize: string;
+
+  @IsNumberString()
+  @IsNotEmpty()
+  maxMessageSize: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,23 @@
+import { InternalServerErrorException } from '@nestjs/common';
+import { TNode, getNodeEndpointOption } from '@paraspell/sdk';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+
 export const isNumeric = (num: any) => !isNaN(num);
+
+export const createApiInstance = async (wsUrl: string) => {
+  const wsProvider = new WsProvider(wsUrl);
+  return await ApiPromise.create({ provider: wsProvider });
+};
+
+export const findWsUrlByNode = (node: TNode) => {
+  const nodeInfo = getNodeEndpointOption(node);
+  const providers = Object.values(nodeInfo.providers);
+
+  if (providers.length < 1) {
+    throw new InternalServerErrorException(
+      `We couldn't find any WS url for node ${node}. Check your @polkadot/apps-config dependency version or open an issue here https://github.com/paraspell/xcm-api`,
+    );
+  }
+
+  return providers[0];
+};

--- a/src/x-transfer/x-transfer.service.ts
+++ b/src/x-transfer/x-transfer.service.ts
@@ -10,30 +10,16 @@ import {
   NODE_NAMES,
   TNode,
   TSerializedApiCall,
-  getNodeEndpointOption,
   getRelayChainSymbol,
 } from '@paraspell/sdk';
-import { ApiPromise, WsProvider } from '@polkadot/api';
 import { XTransferDto } from './dto/XTransferDto';
+import { createApiInstance, findWsUrlByNode } from 'src/utils';
 
 const getNodeRelayChainWsUrl = (destinationNode: TNode) => {
   const symbol = getRelayChainSymbol(destinationNode);
   const POLKADOT_WS = 'wss://kusama-rpc.polkadot.io';
   const KUSAMA_WS = 'wss://rpc.polkadot.io';
   return symbol === 'DOT' ? POLKADOT_WS : KUSAMA_WS;
-};
-
-const findWsUrlByNode = (node: TNode) => {
-  const nodeInfo = getNodeEndpointOption(node);
-  const providers = Object.values(nodeInfo.providers);
-
-  if (providers.length < 1) {
-    throw new InternalServerErrorException(
-      `We couldn't find any WS url for node ${node}. Check your @polkadot/apps-config dependency version or open an issue here https://github.com/paraspell/xcm-api`,
-    );
-  }
-
-  return providers[0];
 };
 
 const determineWsUrl = (fromNode?: TNode, destinationNode?: TNode) => {
@@ -68,8 +54,7 @@ export class XTransferService {
     }
 
     const wsUrl = determineWsUrl(from as TNode, to as TNode);
-    const wsProvider = new WsProvider(wsUrl);
-    const api = await ApiPromise.create({ provider: wsProvider });
+    const api = await createApiInstance(wsUrl);
 
     let builder: any = Builder(api);
 


### PR DESCRIPTION
**Pull Request Documentation**

This pull request introduces two new endpoints to the HRMP (Horizontal Relay Message Passing) Pallet channels in the LightSpell✨ API. These endpoints allow clients to interact with HRMP channels by opening and closing them.

The code changes include the following files:

1. `channels.controller.ts`: This file implements the ChannelsController, which handles incoming requests related to HRMP channel operations. It includes two endpoints: `openChannel` and `closeChannel`. The `openChannel` endpoint is used to initiate the opening of a new HRMP channel, while the `closeChannel` endpoint is used to initiate the closing of an existing HRMP channel.

2. `channels.module.ts`: This file defines the ChannelsModule, which manages the ChannelsController and ChannelsService.

3. `channels.service.ts`: This file implements the ChannelsService, which provides the functionality for opening and closing HRMP channels. It interacts with the @paraspell/sdk library and utilizes utility functions from `src/utils.ts`. The `openChannel` function constructs the necessary details to open a channel, while the `closeChannel` function constructs the details to close a channel.

4. `open-channel.dto.ts` and `close-channel.dto.ts`: These files define the DTOs (Data Transfer Objects) for the request bodies of the `openChannel` and `closeChannel` endpoints, respectively. They specify the required parameters and include validation rules.

The added endpoints and their corresponding request bodies enable clients to interact with HRMP channels in a RESTful manner within the LightSpell✨ API. Clients can initiate the opening of a new channel by providing the origin Parachain, destination Parachain, maximum size, and maximum message size. Similarly, clients can initiate the closing of a channel by providing the origin Parachain, inbound channel identifier, and outbound channel identifier. The API responds with the serialized API call representing the requested HRMP operation.

## Open HRMP Channel

**Endpoint:** `POST /hrmp/channels`

Creates a new HRMP channel.

**Query Parameters:**

- `from` (required): Specifies the origin Parachain.
- `to` (required): Specifies the destination Parachain.
- `maxSize` (required): Specifies the maximum size.
- `maxMessageSize` (required): Specifies the maximum message size.

**Example Request:**

```http
POST /hrmp/channels?from=Karura&to=Basilisk&maxSize=8&maxMessageSize=1024
```

**Example Response:**

```json
{
	"module": "parasSudoWrapper",
	"section": "sudoEstablishHrmpChannel",
	"parameters": [
		2000,
		2090,
		8,
		1024
	]
}
```

**Errors**:
- 400 (Bad request exception) - Returned when query parameters 'from' or 'to' are not provided
- 400 (Bad request exception) - Returned when query parameters 'from' or 'to' are not a valid nodes
- 400 (Bad request exception) - Returned when query parameter 'maxSize' pr 'maxMessageSize' is not provided
- 500 (Internal server error) - Returned when an unknown error has occured. In this case please open an issue.

## Close HRMP Channel

**Endpoint:** `DELETE /hrmp/channels`

Closes an existing HRMP channel.

**Query Parameters:**

- `from` (required): Specifies the origin Parachain.
- `inbound` (required): Specifies the maximum inbound.
- `outbound` (required): Specifies the maximum outbound.

**Example Request:**

```http
DELETE /hrmp/channels?from=Karura&inbound=0&outbound=0
```

**Example Response:**

```json
{
	"module": "hrmp",
	"section": "forceCleanHrmp",
	"parameters": [
		2000,
		0,
		0
	]
}
```

**Errors**:
- 400 (Bad request exception) - Returned when query parameters 'from' is not provided
- 400 (Bad request exception) - Returned when query parameters 'from' is not a valid node
- 400 (Bad request exception) - Returned when query parameter 'inbound' pr 'outbound' is not provided
- 500 (Internal server error) - Returned when an unknown error has occured. In this case please open an issue.