### PR TITLE
Add endpoints for retrieving default and all supported pallets

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { XTransferModule } from './x-transfer/x-transfer.module';
 import { AssetsModule } from './assets/assets.module';
 import { ChannelsModule } from './channels/channels.module';
+import { PalletsModule } from './pallets/pallets.module';
 
 @Module({
-  imports: [XTransferModule, AssetsModule, ChannelsModule],
+  imports: [XTransferModule, AssetsModule, ChannelsModule, PalletsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import {
   NODE_NAMES,
   TNode,
@@ -17,14 +13,7 @@ import {
   getTNode,
   hasSupportForAsset,
 } from '@paraspell/sdk';
-
-const validateNode = (node: string) => {
-  if (!NODE_NAMES.includes(node as TNode)) {
-    throw new BadRequestException(
-      `Node ${node} is not valid. Check docs for valid nodes.`,
-    );
-  }
-};
+import { validateNode } from 'src/utils';
 
 @Injectable()
 export class AssetsService {

--- a/src/pallets/pallets.controller.spec.ts
+++ b/src/pallets/pallets.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PalletsController } from './pallets.controller';
+import { PalletsService } from './pallets.service';
+
+describe('PalletsController', () => {
+  let controller: PalletsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PalletsController],
+      providers: [PalletsService],
+    }).compile();
+
+    controller = module.get<PalletsController>(PalletsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/pallets/pallets.controller.ts
+++ b/src/pallets/pallets.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { PalletsService } from './pallets.service';
+
+@Controller('pallets')
+export class PalletsController {
+  constructor(private readonly palletsService: PalletsService) {}
+
+  @Get(':node/default')
+  getDefaultPallet(@Param('node') node: string) {
+    return this.palletsService.getDefaultPallet(node);
+  }
+
+  @Get(':node/supported')
+  getSupportedPallets(@Param('node') node: string) {
+    return this.palletsService.getSupportedPallets(node);
+  }
+}

--- a/src/pallets/pallets.module.ts
+++ b/src/pallets/pallets.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PalletsService } from './pallets.service';
+import { PalletsController } from './pallets.controller';
+
+@Module({
+  controllers: [PalletsController],
+  providers: [PalletsService],
+})
+export class PalletsModule {}

--- a/src/pallets/pallets.service.spec.ts
+++ b/src/pallets/pallets.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PalletsService } from './pallets.service';
+
+describe('PalletsService', () => {
+  let service: PalletsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PalletsService],
+    }).compile();
+
+    service = module.get<PalletsService>(PalletsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/pallets/pallets.service.ts
+++ b/src/pallets/pallets.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { TNode, getDefaultPallet, getSupportedPallets } from '@paraspell/sdk';
+import { validateNode } from 'src/utils';
+
+@Injectable()
+export class PalletsService {
+  getDefaultPallet(node: string) {
+    validateNode(node);
+    return getDefaultPallet(node as TNode);
+  }
+
+  getSupportedPallets(node: string) {
+    validateNode(node);
+    return getSupportedPallets(node as TNode);
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,8 @@
-import { InternalServerErrorException } from '@nestjs/common';
-import { TNode, getNodeEndpointOption } from '@paraspell/sdk';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { NODE_NAMES, TNode, getNodeEndpointOption } from '@paraspell/sdk';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
 export const isNumeric = (num: any) => !isNaN(num);
@@ -20,4 +23,12 @@ export const findWsUrlByNode = (node: TNode) => {
   }
 
   return providers[0];
+};
+
+export const validateNode = (node: string) => {
+  if (!NODE_NAMES.includes(node as TNode)) {
+    throw new BadRequestException(
+      `Node ${node} is not valid. Check docs for valid nodes.`,
+    );
+  }
 };


### PR DESCRIPTION
## Pull Request Documentation

This pull request introduces changes to the codebase that add two new endpoints for retrieving default pallet and all supported pallets of a specific parachain. The changes include modifications to the module imports, addition of controller and service files, and updates to the utility file.

### Changes Made

- The `AssetsService` has been updated to import the `validateNode` function from the `utils.ts` file, reducing code duplication.
- The `PalletsController` has been added, which contains two endpoints: `GET /pallets/:node/default` and `GET /pallets/:node/supported`. These endpoints allow retrieving the default pallet and the list of supported pallets for a specific node, respectively.
- The `PalletsService` has been implemented to handle the business logic for retrieving default pallets and supported pallets. It utilizes the `validateNode` function to validate the provided node parameter.
- The `PalletsModule` has been created to handle the dependency injection for the `PalletsController` and `PalletsService`.
- The `validateNode` function has been added to the `utils.ts` file to validate the node parameter against the list of valid node names.

### New Endpoints

#### Retrieve Default Pallet

**Endpoint:** `GET /pallets/:node/default`

Retrieves the default pallet for a specified node.

**Path Parameter:**

- `node` (required): Specifies the node for which the default pallet is to be retrieved.

**Example Request:**

```http
GET /pallets/Acala/default
```

**Example Response:**

```
XTokens
```

**Errors**:
- 400 (Bad request exception) - Returned when path parameter 'node' is not a valid node
- 500 (Internal server error) - Returned when an unknown error has occured. In this case please open an issue.

#### Retrieve Supported Pallets

**Endpoint:** `GET /pallets/:node/supported`

Retrieves the list of supported pallets for a specified node.

**Path Parameter:**

- `node` (required): Specifies the node for which the supported pallets are to be retrieved.

**Example Request:**

```http
GET /pallets/Acala/supported
```

**Example Response:**

```json
[
	"PolkadotXcm",
	"XTokens"
]
```

**Errors**:
- 400 (Bad request exception) - Returned when path parameter 'node' is not a valid node
- 500 (Internal server error) - Returned when an unknown error has occured. In this case please open an issue.

These new endpoints provide the ability to retrieve information about default pallets and supported pallets, enabling users to interact with the XCM transactions more efficiently.