### PR TITLE
Add integration tests, unit tests && Github CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: corepack enable
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm format:check
+      - run: pnpm lint
+      - run: pnpm build
+      - run: pnpm test
+      - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint \"src/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
@@ -72,6 +73,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    }
   }
 }

--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from './app.module';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { XTransferModule } from './x-transfer/x-transfer.module';
+import { AssetsModule } from './assets/assets.module';
+import { ChannelsModule } from './channels/channels.module';
+import { PalletsModule } from './pallets/pallets.module';
+
+describe('AppModule', () => {
+  let appModule: TestingModule;
+
+  beforeAll(async () => {
+    appModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  });
+
+  it('should be defined', () => {
+    expect(appModule).toBeDefined();
+  });
+
+  it('should have the correct controllers', () => {
+    const controllers = appModule.get<AppController>(AppController);
+    expect(controllers).toBeDefined();
+  });
+
+  it('should have the correct providers', () => {
+    const providers = appModule.get<AppService>(AppService);
+    expect(providers).toBeDefined();
+  });
+
+  it('should have the correct module imports', () => {
+    const xTransferModule = appModule.select(XTransferModule);
+    const assetsModule = appModule.select(AssetsModule);
+    const channelsModule = appModule.select(ChannelsModule);
+    const palletsModule = appModule.select(PalletsModule);
+
+    expect(xTransferModule).toBeDefined();
+    expect(assetsModule).toBeDefined();
+    expect(channelsModule).toBeDefined();
+    expect(palletsModule).toBeDefined();
+  });
+});

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -1,9 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AssetsController } from './assets.controller';
 import { AssetsService } from './assets.service';
+import { TNode } from '@paraspell/sdk';
 
+// Integration tests to ensure controller and service are working together
 describe('AssetsController', () => {
   let controller: AssetsController;
+  let assetsService: AssetsService;
+  const node: TNode = 'Acala';
+  const symbol = 'KSM';
+  const decimals = 18;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +18,177 @@ describe('AssetsController', () => {
     }).compile();
 
     controller = module.get<AssetsController>(AssetsController);
+    assetsService = module.get<AssetsService>(AssetsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getNodeNames', () => {
+    it('should return the list of node names', () => {
+      const mockResult = ['Acala', 'Basilisk'];
+      jest
+        .spyOn(assetsService, 'getNodeNames' as any)
+        .mockReturnValue(mockResult);
+
+      const result = controller.getNodeNames();
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getNodeNames).toHaveBeenCalled();
+    });
+  });
+
+  describe('getNodeNames', () => {
+    it('should return the list of node names', () => {
+      const mockResult = [node, 'Basilisk'];
+      jest
+        .spyOn(assetsService, 'getNodeNames' as any)
+        .mockReturnValue(mockResult);
+
+      const result = controller.getNodeNames();
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getNodeNames).toHaveBeenCalled();
+    });
+  });
+
+  describe('getAssetsObject', () => {
+    const mockResult = {
+      paraId: 2009,
+      relayChainAssetSymbol: 'KSM',
+      nativeAssets: [{ symbol, decimals }],
+      otherAssets: [{ assetId: '234123123', symbol: 'FKK', decimals }],
+    };
+    it('should return assets object for a valid node', () => {
+      jest
+        .spyOn(assetsService, 'getAssetsObject' as any)
+        .mockReturnValue(mockResult);
+
+      const result = controller.getAssetsObject(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getAssetsObject).toHaveBeenCalledWith(node);
+    });
+
+    it('should return assets object for a valid parachain id', () => {
+      const paraId = '2009';
+      jest
+        .spyOn(assetsService, 'getNodeByParaId' as any)
+        .mockReturnValue(mockResult);
+
+      const result = controller.getAssetsObject(paraId);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getNodeByParaId).toHaveBeenCalledWith(
+        Number(paraId),
+      );
+    });
+  });
+
+  describe('getAssetId', () => {
+    it('should return asset ID for a valid node and symbol', () => {
+      const symbol = 'DOT';
+      const mockResult = '1';
+      jest.spyOn(assetsService, 'getAssetId').mockReturnValue(mockResult);
+
+      const result = controller.getAssetId(node, symbol);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getAssetId).toHaveBeenCalledWith(node, symbol);
+    });
+  });
+
+  describe('getRelayChainSymbol', () => {
+    it('should return relay chain symbol for a valid node', () => {
+      const mockResult = 'KSM';
+      jest
+        .spyOn(assetsService, 'getRelayChainSymbol')
+        .mockReturnValue(mockResult);
+
+      const result = controller.getRelayChainSymbol(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getRelayChainSymbol).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getNativeAssets', () => {
+    it('should return native assets for a valid node', () => {
+      const mockResult = [{ symbol, decimals }];
+      jest.spyOn(assetsService, 'getNativeAssets').mockReturnValue(mockResult);
+
+      const result = controller.getNativeAssets(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getNativeAssets).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getOtherAssets', () => {
+    it('should return other assets for a valid node', () => {
+      const mockResult = [{ assetId: '234123123', symbol: 'FKK', decimals }];
+      jest.spyOn(assetsService, 'getOtherAssets').mockReturnValue(mockResult);
+
+      const result = controller.getOtherAssets(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getOtherAssets).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getAllAssetsSymbol', () => {
+    it('should return all assets symbols for a valid node', () => {
+      const mockResult = [symbol, 'DOT'];
+      jest
+        .spyOn(assetsService, 'getAllAssetsSymbols')
+        .mockReturnValue(mockResult);
+
+      const result = controller.getAllAssetsSymbol(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getAllAssetsSymbols).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getDecimals', () => {
+    it('should return decimals for a valid node and symbol', () => {
+      const mockResult = 18;
+      jest.spyOn(assetsService, 'getDecimals').mockReturnValue(mockResult);
+
+      const result = controller.getDecimals(node, symbol);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getDecimals).toHaveBeenCalledWith(node, symbol);
+    });
+  });
+
+  describe('hasSupportForAsset', () => {
+    it('should return true if asset is supported for a valid node and symbol', () => {
+      const mockResult = true;
+      jest
+        .spyOn(assetsService, 'hasSupportForAsset')
+        .mockReturnValue(mockResult);
+
+      const result = controller.hasSupportForAsset(node, symbol);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.hasSupportForAsset).toHaveBeenCalledWith(
+        node,
+        symbol,
+      );
+    });
+  });
+
+  describe('getParaId', () => {
+    it('should return parachain id for a valid node', () => {
+      const mockResult = 2009;
+      jest.spyOn(assetsService, 'getParaId').mockReturnValue(mockResult);
+
+      const result = controller.getParaId(node);
+
+      expect(result).toBe(mockResult);
+      expect(assetsService.getParaId).toHaveBeenCalledWith(node);
+    });
   });
 });

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { AssetsService } from './assets.service';
 import { isNumeric } from 'src/utils';
 
@@ -46,7 +46,7 @@ export class AssetsController {
   }
 
   @Get(':node/decimals/:symbol')
-  decimals(@Param('node') node: string, @Param('symbol') symbol: string) {
+  getDecimals(@Param('node') node: string, @Param('symbol') symbol: string) {
     return this.assetsService.getDecimals(node, symbol);
   }
 

--- a/src/assets/assets.module.ts
+++ b/src/assets/assets.module.ts
@@ -4,6 +4,6 @@ import { AssetsController } from './assets.controller';
 
 @Module({
   controllers: [AssetsController],
-  providers: [AssetsService]
+  providers: [AssetsService],
 })
 export class AssetsModule {}

--- a/src/assets/assets.service.spec.ts
+++ b/src/assets/assets.service.spec.ts
@@ -1,8 +1,20 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AssetsService } from './assets.service';
+import * as paraspellSdk from '@paraspell/sdk';
+import { TNode } from '@paraspell/sdk';
+import * as utils from '../utils';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('AssetsService', () => {
   let service: AssetsService;
+  let validateNodeSpy: jest.SpyInstance;
+  const node: TNode = 'Acala';
+  const invalidNode = 'InvalidNode';
+  const symbol = 'DOT';
+  const unknownSymbol = 'UNKNOWN';
+  const assetId = '1';
+  const paraId = 2000;
+  const decimals = 12;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -10,9 +22,340 @@ describe('AssetsService', () => {
     }).compile();
 
     service = module.get<AssetsService>(AssetsService);
+
+    validateNodeSpy = jest.spyOn(utils, 'validateNode');
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getNodeNames', () => {
+    it('should return the list of node names', () => {
+      const result = service.getNodeNames();
+      expect(result).toEqual(paraspellSdk.NODE_NAMES);
+    });
+  });
+
+  describe('getAssetsObject', () => {
+    let getAssetsObjectSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      getAssetsObjectSpy = jest.spyOn(paraspellSdk, 'getAssetsObject');
+    });
+
+    afterEach(() => {
+      getAssetsObjectSpy.mockRestore();
+    });
+
+    it('should return assets object for a valid node', () => {
+      const assetsObject: paraspellSdk.TNodeAssets = {
+        paraId,
+        relayChainAssetSymbol: symbol,
+        nativeAssets: [{ symbol, decimals }],
+        otherAssets: [{ assetId, symbol: 'BSK', decimals }],
+      };
+      getAssetsObjectSpy.mockReturnValue(assetsObject);
+
+      const result = service.getAssetsObject(node);
+      expect(result).toEqual(assetsObject);
+      expect(validateNodeSpy).toHaveBeenCalledWith(node);
+      expect(getAssetsObjectSpy).toHaveBeenCalledWith(node);
+    });
+
+    it('should throw if node is invalid', () => {
+      expect(() => service.getAssetsObject(invalidNode)).toThrow(
+        BadRequestException,
+      );
+
+      expect(validateNodeSpy).toHaveBeenCalledWith(invalidNode);
+      expect(getAssetsObjectSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAssetId', () => {
+    let getAssetIdSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getAssetIdSpy = jest.spyOn(paraspellSdk, 'getAssetId');
+    });
+
+    afterEach(() => {
+      getAssetIdSpy.mockRestore();
+    });
+
+    it('should return asset ID for a valid node and symbol', () => {
+      getAssetIdSpy.mockReturnValue(assetId);
+
+      const result = service.getAssetId(node, symbol);
+
+      expect(result).toEqual(assetId);
+      expect(getAssetIdSpy).toHaveBeenCalledWith(node, symbol);
+    });
+
+    it('should throw NotFoundException for unknown symbol', () => {
+      getAssetIdSpy.mockReturnValue(null);
+
+      expect(() => service.getAssetId(node, unknownSymbol)).toThrow(
+        NotFoundException,
+      );
+      expect(getAssetIdSpy).toHaveBeenCalledWith(node, unknownSymbol);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getAssetId(invalidNode, symbol)).toThrow(
+        BadRequestException,
+      );
+      expect(getAssetIdSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRelayChainSymbol', () => {
+    let getRelayChainSymbolSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getRelayChainSymbolSpy = jest.spyOn(paraspellSdk, 'getRelayChainSymbol');
+    });
+
+    afterEach(() => {
+      getRelayChainSymbolSpy.mockRestore();
+    });
+
+    it('should return relay chain symbol for a valid node', () => {
+      const relayChainSymbol = 'KSM';
+      getRelayChainSymbolSpy.mockReturnValue(relayChainSymbol);
+
+      const result = service.getRelayChainSymbol(node);
+
+      expect(result).toEqual(JSON.stringify(relayChainSymbol));
+      expect(getRelayChainSymbolSpy).toHaveBeenCalledWith(node);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getRelayChainSymbol(invalidNode)).toThrow(
+        BadRequestException,
+      );
+      expect(getRelayChainSymbolSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getNativeAssets', () => {
+    let getNativeAssetsSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getNativeAssetsSpy = jest.spyOn(paraspellSdk, 'getNativeAssets');
+    });
+
+    afterEach(() => {
+      getNativeAssetsSpy.mockRestore();
+    });
+
+    it('should return native assets for a valid node', () => {
+      const nativeAssets = [{ symbol: 'KSM', decimals }];
+      getNativeAssetsSpy.mockReturnValue(nativeAssets);
+
+      const result = service.getNativeAssets(node);
+
+      expect(result).toEqual(nativeAssets);
+      expect(getNativeAssetsSpy).toHaveBeenCalledWith(node);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getNativeAssets(invalidNode)).toThrow(
+        BadRequestException,
+      );
+      expect(getNativeAssetsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getOtherAssets', () => {
+    let getOtherAssetsSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getOtherAssetsSpy = jest.spyOn(paraspellSdk, 'getOtherAssets');
+    });
+
+    afterEach(() => {
+      getOtherAssetsSpy.mockRestore();
+    });
+
+    it('should return other assets for a valid node', () => {
+      const otherAssets = [{ assetId, symbol: 'BSK', decimals }];
+      getOtherAssetsSpy.mockReturnValue(otherAssets);
+
+      const result = service.getOtherAssets(node);
+
+      expect(result).toEqual(otherAssets);
+      expect(getOtherAssetsSpy).toHaveBeenCalledWith(node);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getOtherAssets(invalidNode)).toThrow(
+        BadRequestException,
+      );
+      expect(getOtherAssetsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getAllAssetsSymbols', () => {
+    let getAllAssetsSymbolsSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getAllAssetsSymbolsSpy = jest.spyOn(paraspellSdk, 'getAllAssetsSymbols');
+    });
+
+    afterEach(() => {
+      getAllAssetsSymbolsSpy.mockRestore();
+    });
+
+    it('should return all assets symbols for a valid node', () => {
+      const allAssetSymbols = ['KSM', 'DOT'];
+      getAllAssetsSymbolsSpy.mockReturnValue(allAssetSymbols);
+
+      const result = service.getAllAssetsSymbols(node);
+
+      expect(result).toEqual(allAssetSymbols);
+      expect(getAllAssetsSymbolsSpy).toHaveBeenCalledWith(node);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getAllAssetsSymbols(invalidNode)).toThrow(
+        BadRequestException,
+      );
+      expect(getAllAssetsSymbolsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getDecimals', () => {
+    let getAssetDecimalsSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getAssetDecimalsSpy = jest.spyOn(paraspellSdk, 'getAssetDecimals');
+    });
+
+    afterEach(() => {
+      getAssetDecimalsSpy.mockRestore();
+    });
+
+    it('should return asset decimals for a valid node and symbol', () => {
+      const node = 'Acala';
+      const symbol = 'DOT';
+      const decimals = 18;
+      getAssetDecimalsSpy.mockReturnValue(decimals);
+
+      const result = service.getDecimals(node, symbol);
+
+      expect(result).toEqual(decimals);
+      expect(getAssetDecimalsSpy).toHaveBeenCalledWith(node, symbol);
+    });
+
+    it('should throw NotFoundException for unknown symbol', () => {
+      getAssetDecimalsSpy.mockReturnValue(null);
+
+      expect(() => service.getDecimals(node, unknownSymbol)).toThrow(
+        NotFoundException,
+      );
+      expect(getAssetDecimalsSpy).toHaveBeenCalledWith(node, unknownSymbol);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.getDecimals(invalidNode, symbol)).toThrow(
+        BadRequestException,
+      );
+      expect(getAssetDecimalsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasSupportForAsset', () => {
+    let hasSupportForAssetSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      hasSupportForAssetSpy = jest.spyOn(paraspellSdk, 'hasSupportForAsset');
+    });
+
+    afterEach(() => {
+      hasSupportForAssetSpy.mockRestore();
+    });
+
+    it('should return true if asset is supported for a valid node and symbol', () => {
+      hasSupportForAssetSpy.mockReturnValue(true);
+
+      const result = service.hasSupportForAsset(node, symbol);
+
+      expect(result).toEqual(true);
+      expect(hasSupportForAssetSpy).toHaveBeenCalledWith(node, symbol);
+    });
+
+    it('should return false if asset is not supported for a valid node and symbol', () => {
+      hasSupportForAssetSpy.mockReturnValue(false);
+
+      const result = service.hasSupportForAsset(node, unknownSymbol);
+
+      expect(result).toEqual(false);
+      expect(hasSupportForAssetSpy).toHaveBeenCalledWith(node, unknownSymbol);
+    });
+
+    it('should throw BadRequestException for invalid node', () => {
+      expect(() => service.hasSupportForAsset(invalidNode, symbol)).toThrow(
+        BadRequestException,
+      );
+      expect(hasSupportForAssetSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AssetsService', () => {
+    let getParaIdSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getParaIdSpy = jest.spyOn(paraspellSdk, 'getParaId');
+    });
+
+    afterEach(() => {
+      getParaIdSpy.mockRestore();
+    });
+
+    describe('getParaId', () => {
+      it('should return parachain ID for a valid node', () => {
+        const result = service.getParaId(node);
+
+        expect(result).toEqual(paraId);
+        expect(getParaIdSpy).toHaveBeenCalledWith(node);
+      });
+
+      it('should throw BadRequestException for invalid node', () => {
+        expect(() => service.getParaId(invalidNode)).toThrow(
+          BadRequestException,
+        );
+        expect(getParaIdSpy).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getNodeByParaId', () => {
+    let getTNodeSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      getTNodeSpy = jest.spyOn(paraspellSdk, 'getTNode');
+    });
+
+    afterEach(() => {
+      getTNodeSpy.mockRestore();
+    });
+
+    it('should return node by parachain ID', () => {
+      const result = service.getNodeByParaId(paraId);
+
+      expect(result).toEqual(JSON.stringify(node));
+      expect(getTNodeSpy).toHaveBeenCalledWith(paraId);
+    });
+
+    it('should throw NotFoundException for unknown parachain ID', () => {
+      const unknownParaId = 999;
+
+      expect(() => service.getNodeByParaId(unknownParaId)).toThrow(
+        NotFoundException,
+      );
+      expect(getTNodeSpy).toHaveBeenCalledWith(unknownParaId);
+    });
   });
 });

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -1,9 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelsController } from './channels.controller';
 import { ChannelsService } from './channels.service';
+import { OpenChannelDto } from './dto/open-channel.dto';
+import { CloseChannelDto } from './dto/close-channel.dto';
 
+// Integration tests to ensure controller and service are working together
 describe('ChannelsController', () => {
   let controller: ChannelsController;
+  let channelsService: ChannelsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +16,51 @@ describe('ChannelsController', () => {
     }).compile();
 
     controller = module.get<ChannelsController>(ChannelsController);
+    channelsService = module.get<ChannelsService>(ChannelsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('openChannel', () => {
+    it('should open a channel and return the result', async () => {
+      const openChannelDto: OpenChannelDto = {
+        from: 'Acala',
+        to: 'Basilisk',
+        maxSize: '512',
+        maxMessageSize: '256',
+      };
+      const mockResult = 'serialized-api-call';
+      jest
+        .spyOn(channelsService, 'openChannel' as any)
+        .mockResolvedValue(mockResult);
+
+      const result = await controller.openChannel(openChannelDto);
+
+      expect(result).toBe(mockResult);
+      expect(channelsService.openChannel).toHaveBeenCalledWith(openChannelDto);
+    });
+  });
+
+  describe('closeChannel', () => {
+    it('should close a channel and return the result', async () => {
+      const closeChannelDto: CloseChannelDto = {
+        from: 'Acala',
+        inbound: '1',
+        outbound: '2',
+      };
+      const mockResult = 'serialized-api-call';
+      jest
+        .spyOn(channelsService, 'closeChannel' as any)
+        .mockResolvedValue(mockResult);
+
+      const result = await controller.closeChannel(closeChannelDto);
+
+      expect(result).toBe(mockResult);
+      expect(channelsService.closeChannel).toHaveBeenCalledWith(
+        closeChannelDto,
+      );
+    });
   });
 });

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -1,8 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChannelsService } from './channels.service';
+import { BadRequestException } from '@nestjs/common';
+import * as paraspellSdk from '@paraspell/sdk';
+import { TNode } from '@paraspell/sdk';
 
 describe('ChannelsService', () => {
   let service: ChannelsService;
+  const maxSize = '512';
+  const maxMessageSize = '512';
+  const inbound = '50';
+  const outbound = '40';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -14,5 +21,122 @@ describe('ChannelsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('openChannel', () => {
+    it('should open a channel with valid parameters', async () => {
+      const from: TNode = 'Acala';
+      const to: TNode = 'Basilisk';
+
+      const mockOpenChannelDto = {
+        from,
+        to,
+        maxSize,
+        maxMessageSize,
+      };
+
+      // Mock the relevant builder interfaces
+      const mockBuilder = {
+        from: jest.fn().mockReturnThis(),
+        to: jest.fn().mockReturnThis(),
+        openChannel: jest.fn().mockReturnThis(),
+        maxSize: jest.fn().mockReturnThis(),
+        maxMessageSize: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest
+          .fn()
+          .mockReturnValue('serialized-api-call'),
+      };
+      const builderSpy = jest
+        .spyOn(paraspellSdk, 'Builder')
+        .mockReturnValue(mockBuilder as any);
+
+      const result = await service.openChannel(mockOpenChannelDto);
+
+      expect(result).toBe('serialized-api-call');
+      expect(builderSpy).toHaveBeenCalledWith(null); // Check if Builder is called with the expected parameter
+      expect(mockBuilder.from).toHaveBeenCalledWith(from);
+      expect(mockBuilder.to).toHaveBeenCalledWith(to);
+      expect(mockBuilder.maxSize).toHaveBeenCalledWith(Number(maxSize));
+      expect(mockBuilder.maxMessageSize).toHaveBeenCalledWith(
+        Number(maxMessageSize),
+      );
+    });
+
+    it('should throw BadRequestException for invalid from node', async () => {
+      const from = 'InvalidNode';
+      const to: TNode = 'Basilisk';
+      const mockOpenChannelDto = {
+        from,
+        to,
+        maxSize,
+        maxMessageSize,
+      };
+
+      await expect(service.openChannel(mockOpenChannelDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException for invalid to node', async () => {
+      const from: TNode = 'Basilisk';
+      const to = 'InvalidNode';
+      const mockOpenChannelDto = {
+        from,
+        to,
+        maxSize,
+        maxMessageSize,
+      };
+
+      await expect(service.openChannel(mockOpenChannelDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('closeChannel', () => {
+    it('should close a channel with valid parameters', async () => {
+      const from: TNode = 'Acala';
+
+      const mockCloseChannelDto = {
+        from,
+        inbound,
+        outbound,
+      };
+
+      const mockBuilder = {
+        from: jest.fn().mockReturnThis(),
+        inbound: jest.fn().mockReturnThis(),
+        outbound: jest.fn().mockReturnThis(),
+        closeChannel: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest
+          .fn()
+          .mockReturnValue('serialized-api-call'),
+      };
+
+      const builderSpy = jest
+        .spyOn(paraspellSdk, 'Builder')
+        .mockReturnValue(mockBuilder as any);
+
+      const result = await service.closeChannel(mockCloseChannelDto);
+
+      expect(result).toBe('serialized-api-call');
+      expect(builderSpy).toHaveBeenCalledWith(null);
+      expect(mockBuilder.from).toHaveBeenCalledWith(from);
+      expect(mockBuilder.inbound).toHaveBeenCalledWith(Number(inbound));
+      expect(mockBuilder.outbound).toHaveBeenCalledWith(Number(outbound));
+    });
+
+    it('should throw BadRequestException for invalid nodes', async () => {
+      const from = 'InvalidNode';
+      const mockCloseChannelDto = {
+        from,
+        inbound,
+        outbound,
+      };
+
+      await expect(service.closeChannel(mockCloseChannelDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 });

--- a/src/pallets/pallets.controller.spec.ts
+++ b/src/pallets/pallets.controller.spec.ts
@@ -1,9 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PalletsController } from './pallets.controller';
 import { PalletsService } from './pallets.service';
+import { TNode, TPallet } from '@paraspell/sdk';
 
+// Integration tests to ensure controller and service are working together
 describe('PalletsController', () => {
   let controller: PalletsController;
+  let palletsService: PalletsService;
+  const node: TNode = 'Acala';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +16,38 @@ describe('PalletsController', () => {
     }).compile();
 
     controller = module.get<PalletsController>(PalletsController);
+    palletsService = module.get<PalletsService>(PalletsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getDefaultPallet', () => {
+    it('should return the default pallet for the given node', async () => {
+      const defaultPallet: TPallet = 'OrmlXTokens';
+      jest
+        .spyOn(palletsService, 'getDefaultPallet' as any)
+        .mockResolvedValue(defaultPallet);
+
+      const result = await controller.getDefaultPallet(node);
+
+      expect(result).toBe(defaultPallet);
+      expect(palletsService.getDefaultPallet).toHaveBeenCalledWith(node);
+    });
+  });
+
+  describe('getPallets', () => {
+    it('should return the list of pallets for the given node', async () => {
+      const pallets: TPallet[] = ['OrmlXTokens', 'PolkadotXcm'];
+      jest
+        .spyOn(palletsService, 'getPallets' as any)
+        .mockResolvedValue(pallets);
+
+      const result = await controller.getPallets(node);
+
+      expect(result).toBe(pallets);
+      expect(palletsService.getPallets).toHaveBeenCalledWith(node);
+    });
   });
 });

--- a/src/pallets/pallets.service.spec.ts
+++ b/src/pallets/pallets.service.spec.ts
@@ -1,8 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PalletsService } from './pallets.service';
+import { TNode, TPallet } from '@paraspell/sdk';
+import * as paraspellSdk from '@paraspell/sdk';
+import * as utils from '../utils';
 
 describe('PalletsService', () => {
   let service: PalletsService;
+  let validateNodeSpy: jest.SpyInstance;
+  let getDefaultPalletSpy: jest.SpyInstance;
+  let getSupportedPalletsSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -10,9 +16,46 @@ describe('PalletsService', () => {
     }).compile();
 
     service = module.get<PalletsService>(PalletsService);
+    validateNodeSpy = jest.spyOn(utils, 'validateNode');
+    getDefaultPalletSpy = jest.spyOn(paraspellSdk, 'getDefaultPallet');
+    getSupportedPalletsSpy = jest.spyOn(paraspellSdk, 'getSupportedPallets');
+  });
+
+  afterEach(() => {
+    validateNodeSpy.mockRestore();
+    getDefaultPalletSpy.mockRestore();
+    getSupportedPalletsSpy.mockRestore();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getDefaultPallet', () => {
+    it('should return the default pallet as string', () => {
+      const mockNode: TNode = 'Acala';
+      const mockPallet: TPallet = 'PolkadotXcm';
+      getDefaultPalletSpy.mockReturnValue(mockPallet);
+
+      const result = service.getDefaultPallet(mockNode);
+
+      expect(validateNodeSpy).toHaveBeenCalledWith(mockNode);
+      expect(getDefaultPalletSpy).toHaveBeenCalledWith(mockNode);
+      expect(result).toEqual(JSON.stringify(mockPallet));
+    });
+  });
+
+  describe('getPallets', () => {
+    it('should return supported pallets array', () => {
+      const mockNode: TNode = 'Acala';
+      const mockPallets: TPallet[] = ['OrmlXTokens', 'RelayerXcm'];
+      getSupportedPalletsSpy.mockReturnValue(mockPallets);
+
+      const result = service.getPallets(mockNode);
+
+      expect(validateNodeSpy).toHaveBeenCalledWith(mockNode);
+      expect(getSupportedPalletsSpy).toHaveBeenCalledWith(mockNode);
+      expect(result).toEqual(mockPallets);
+    });
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,139 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { ApiPromise } from '@polkadot/api';
+import {
+  isNumeric,
+  createApiInstance,
+  findWsUrlByNode,
+  validateNode,
+  getNodeRelayChainWsUrl,
+} from './utils';
+import * as paraspellSdk from '@paraspell/sdk';
+import { TNode } from '@paraspell/sdk';
+
+jest.mock('@polkadot/api', () => {
+  const originalModule = jest.requireActual('@polkadot/api');
+
+  const mockWsProvider = jest.fn().mockImplementation(() => ({
+    isConnected: true,
+    send: jest.fn(),
+  }));
+
+  const mockApiPromise = {
+    ...originalModule.ApiPromise,
+    create: jest.fn().mockResolvedValue({
+      wsProvider: mockWsProvider,
+    }),
+  };
+
+  return {
+    ...originalModule,
+    WsProvider: mockWsProvider,
+    ApiPromise: mockApiPromise,
+  };
+});
+
+describe('isNumeric', () => {
+  it('should return true for numeric values', () => {
+    expect(isNumeric(123)).toBe(true);
+    expect(isNumeric('123')).toBe(true);
+    expect(isNumeric('0')).toBe(true);
+  });
+
+  it('should return false for non-numeric values', () => {
+    expect(isNumeric('abc')).toBe(false);
+    expect(isNumeric('123abc')).toBe(false);
+    expect(isNumeric(undefined)).toBe(false);
+    expect(isNumeric(NaN)).toBe(false);
+    expect(isNumeric({})).toBe(false);
+  });
+});
+
+describe('createApiInstance', () => {
+  it('should create an ApiPromise instance', async () => {
+    const wsUrl = 'wss://rpc.polkadot.io';
+
+    // Cast ApiPromise.create to a jest.Mock to use mockResolvedValue
+    (ApiPromise.create as jest.Mock).mockResolvedValue({
+      wsProvider: {
+        isConnected: true,
+        send: jest.fn(),
+      },
+    });
+
+    const result = await createApiInstance(wsUrl);
+
+    expect(ApiPromise.create).toHaveBeenCalledWith({
+      provider: expect.any(Object),
+    });
+    expect(result).toEqual({
+      wsProvider: expect.any(Object),
+    });
+  });
+});
+
+describe('findWsUrlByNode', () => {
+  it('should return the first provider WS URL for a valid node', () => {
+    const node: TNode = 'Acala';
+    const nodeInfo = {
+      providers: { provider1: 'wss://provider1', provider2: 'wss://provider2' },
+    };
+    const getNodeEndpointOptionSpy = jest
+      .spyOn(paraspellSdk, 'getNodeEndpointOption')
+      .mockReturnValue(nodeInfo as any);
+
+    const result = findWsUrlByNode(node);
+
+    expect(getNodeEndpointOptionSpy).toHaveBeenCalledWith(node);
+    expect(result).toBe('wss://provider1');
+  });
+
+  it('should throw InternalServerErrorException for node with no providers', () => {
+    const node: TNode = 'Acala';
+    const nodeInfo = { providers: {} };
+    const getNodeEndpointOptionSpy = jest
+      .spyOn(paraspellSdk, 'getNodeEndpointOption')
+      .mockReturnValue(nodeInfo as any);
+
+    expect(() => findWsUrlByNode(node)).toThrow(InternalServerErrorException);
+    expect(getNodeEndpointOptionSpy).toHaveBeenCalledWith(node);
+  });
+});
+
+describe('validateNode', () => {
+  it('should not throw for valid node', () => {
+    expect(() => validateNode('Acala')).not.toThrow();
+  });
+
+  it('should throw BadRequestException for invalid node', () => {
+    expect(() => validateNode('InvalidNode')).toThrow(BadRequestException);
+  });
+});
+
+describe('getNodeRelayChainWsUrl', () => {
+  it('should return POLKADOT_WS for DOT', () => {
+    const symbol = 'DOT';
+    const getRelayChainSymbolSpy = jest
+      .spyOn(paraspellSdk, 'getRelayChainSymbol')
+      .mockReturnValue(symbol);
+
+    const result = getNodeRelayChainWsUrl('Acala');
+
+    expect(getRelayChainSymbolSpy).toHaveBeenCalledWith('Acala');
+    expect(result).toBe('wss://kusama-rpc.polkadot.io');
+  });
+
+  it('should return KUSAMA_WS for non-DOT symbol', () => {
+    const symbol = 'KSM';
+    const getRelayChainSymbolSpy = jest
+      .spyOn(paraspellSdk, 'getRelayChainSymbol')
+      .mockReturnValue(symbol);
+
+    const result = getNodeRelayChainWsUrl('Acala');
+
+    expect(getRelayChainSymbolSpy).toHaveBeenCalledWith('Acala');
+    expect(result).toBe('wss://rpc.polkadot.io');
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,12 @@ import {
   BadRequestException,
   InternalServerErrorException,
 } from '@nestjs/common';
-import { NODE_NAMES, TNode, getNodeEndpointOption } from '@paraspell/sdk';
+import {
+  NODE_NAMES,
+  TNode,
+  getNodeEndpointOption,
+  getRelayChainSymbol,
+} from '@paraspell/sdk';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 
 export const isNumeric = (num: any) => !isNaN(num);
@@ -31,4 +36,11 @@ export const validateNode = (node: string) => {
       `Node ${node} is not valid. Check docs for valid nodes.`,
     );
   }
+};
+
+export const getNodeRelayChainWsUrl = (destinationNode: TNode) => {
+  const symbol = getRelayChainSymbol(destinationNode);
+  const POLKADOT_WS = 'wss://kusama-rpc.polkadot.io';
+  const KUSAMA_WS = 'wss://rpc.polkadot.io';
+  return symbol === 'DOT' ? POLKADOT_WS : KUSAMA_WS;
 };

--- a/src/x-transfer/dto/XTransferDto.ts
+++ b/src/x-transfer/dto/XTransferDto.ts
@@ -1,8 +1,8 @@
 import { IsNotEmpty, IsNumberString } from 'class-validator';
 
 export class XTransferDto {
-  from: string;
-  to: string;
+  from?: string;
+  to?: string;
 
   @IsNotEmpty()
   @IsNumberString()
@@ -11,5 +11,5 @@ export class XTransferDto {
   @IsNotEmpty()
   address: string;
 
-  currency: string;
+  currency?: string;
 }

--- a/src/x-transfer/x-transfer.controller.spec.ts
+++ b/src/x-transfer/x-transfer.controller.spec.ts
@@ -1,9 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { XTransferController } from './x-transfer.controller';
 import { XTransferService } from './x-transfer.service';
+import { XTransferDto } from './dto/XTransferDto';
 
+// Integration tests to ensure controller and service are working together
 describe('XTransferController', () => {
   let controller: XTransferController;
+  let service: XTransferService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -12,9 +15,31 @@ describe('XTransferController', () => {
     }).compile();
 
     controller = module.get<XTransferController>(XTransferController);
+    service = module.get<XTransferService>(XTransferService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('generateXcmCall', () => {
+    it('should call generateXcmCall service method with correct parameters and return result', async () => {
+      const queryParams: XTransferDto = {
+        from: 'Acala',
+        to: 'Basilisk',
+        amount: 100,
+        address: '0x123456789',
+        currency: 'DOT',
+      };
+      const mockResult = 'serialized-api-call';
+      jest
+        .spyOn(service, 'generateXcmCall' as any)
+        .mockResolvedValue(mockResult);
+
+      const result = await controller.generateXcmCall(queryParams);
+
+      expect(result).toBe(mockResult);
+      expect(service.generateXcmCall).toHaveBeenCalledWith(queryParams);
+    });
   });
 });

--- a/src/x-transfer/x-transfer.service.spec.ts
+++ b/src/x-transfer/x-transfer.service.spec.ts
@@ -1,8 +1,27 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { XTransferService } from './x-transfer.service';
+import * as paraspellSdk from '@paraspell/sdk';
+import { TNode, InvalidCurrencyError } from '@paraspell/sdk';
+import { XTransferDto } from './dto/XTransferDto';
+import * as utils from 'src/utils';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 
 describe('XTransferService', () => {
   let service: XTransferService;
+  let createApiInstanceSpy: jest.SpyInstance;
+  let findWsUrlByNodeSpy: jest.SpyInstance;
+  let getNodeRelayChainWsUrlSpy: jest.SpyInstance;
+
+  const amount = 100;
+  const address = '0x123';
+  const currency = 'DOT';
+  const wsUrl = 'wss://example.com';
+  const relayChainWsUrl = 'wss://relaychain.com';
+  const serializedApiCall = 'serialized-api-call';
+  const invalidNode = 'InvalidNode';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -10,9 +29,231 @@ describe('XTransferService', () => {
     }).compile();
 
     service = module.get<XTransferService>(XTransferService);
+    createApiInstanceSpy = jest
+      .spyOn(utils, 'createApiInstance')
+      .mockResolvedValue({} as any);
+    findWsUrlByNodeSpy = jest.spyOn(utils, 'findWsUrlByNode');
+    getNodeRelayChainWsUrlSpy = jest.spyOn(utils, 'getNodeRelayChainWsUrl');
+  });
+
+  afterEach(() => {
+    createApiInstanceSpy.mockRestore();
+    findWsUrlByNodeSpy.mockRestore();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('generateXcmCall', () => {
+    it('should generate XCM call for parachain to parachain transfer', async () => {
+      const from: TNode = 'Acala';
+      const to: TNode = 'Basilisk';
+      const xTransferDto: XTransferDto = {
+        from,
+        to,
+        amount,
+        address,
+        currency,
+      };
+      findWsUrlByNodeSpy.mockReturnValue(wsUrl);
+
+      const builderMock = {
+        from: jest.fn().mockReturnThis(),
+        to: jest.fn().mockReturnThis(),
+        currency: jest.fn().mockReturnThis(),
+        amount: jest.fn().mockReturnThis(),
+        address: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest.fn().mockReturnValue(serializedApiCall),
+      };
+      jest.spyOn(paraspellSdk, 'Builder').mockReturnValue(builderMock as any);
+
+      const result = await service.generateXcmCall(xTransferDto);
+
+      expect(result).toBe(serializedApiCall);
+      expect(createApiInstanceSpy).toHaveBeenCalledWith(wsUrl);
+      expect(findWsUrlByNodeSpy).toHaveBeenCalled();
+      expect(builderMock.from).toHaveBeenCalledWith(from);
+      expect(builderMock.to).toHaveBeenCalledWith(to);
+      expect(builderMock.currency).toHaveBeenCalledWith(currency);
+      expect(builderMock.amount).toHaveBeenCalledWith(amount);
+      expect(builderMock.address).toHaveBeenCalledWith(address);
+      expect(builderMock.buildSerializedApiCall).toHaveBeenCalled();
+    });
+
+    it('should generate XCM call for parachain to relaychain transfer', async () => {
+      const from: TNode = 'Acala';
+
+      const xTransferDto: XTransferDto = {
+        from,
+        amount,
+        address,
+        currency,
+      };
+      findWsUrlByNodeSpy.mockReturnValue(wsUrl);
+
+      const builderMock = {
+        from: jest.fn().mockReturnThis(),
+        amount: jest.fn().mockReturnThis(),
+        address: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest.fn().mockReturnValue(serializedApiCall),
+      };
+      jest.spyOn(paraspellSdk, 'Builder').mockReturnValue(builderMock as any);
+
+      const result = await service.generateXcmCall(xTransferDto);
+
+      expect(result).toBe(serializedApiCall);
+      expect(createApiInstanceSpy).toHaveBeenCalledWith(wsUrl);
+      expect(findWsUrlByNodeSpy).toHaveBeenCalledWith(from);
+      expect(builderMock.from).toHaveBeenCalledWith(from);
+      expect(builderMock.amount).toHaveBeenCalledWith(amount);
+      expect(builderMock.address).toHaveBeenCalledWith(address);
+      expect(builderMock.buildSerializedApiCall).toHaveBeenCalled();
+    });
+
+    it('should generate XCM call for relaychain to parachain transfer', async () => {
+      const to: TNode = 'Acala';
+      const xTransferDto: XTransferDto = {
+        to,
+        amount,
+        address,
+      };
+      findWsUrlByNodeSpy.mockReturnValue(wsUrl);
+      getNodeRelayChainWsUrlSpy.mockReturnValue(relayChainWsUrl);
+
+      const builderMock = {
+        to: jest.fn().mockReturnThis(),
+        amount: jest.fn().mockReturnThis(),
+        address: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest.fn().mockReturnValue(serializedApiCall),
+      };
+      jest.spyOn(paraspellSdk, 'Builder').mockReturnValue(builderMock as any);
+
+      const result = await service.generateXcmCall(xTransferDto);
+
+      expect(result).toBe(serializedApiCall);
+      expect(createApiInstanceSpy).toHaveBeenCalledWith(relayChainWsUrl);
+      expect(findWsUrlByNodeSpy).not.toHaveBeenCalled();
+      expect(getNodeRelayChainWsUrlSpy).toHaveBeenCalledWith(to);
+      expect(builderMock.to).toHaveBeenCalledWith(to);
+      expect(builderMock.amount).toHaveBeenCalledWith(amount);
+      expect(builderMock.address).toHaveBeenCalledWith(address);
+      expect(builderMock.buildSerializedApiCall).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid from node', async () => {
+      const xTransferDto: XTransferDto = {
+        from: invalidNode,
+        amount,
+        address,
+        currency,
+      };
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(createApiInstanceSpy).not.toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid to node', async () => {
+      const xTransferDto: XTransferDto = {
+        to: invalidNode,
+        amount,
+        address,
+        currency,
+      };
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(createApiInstanceSpy).not.toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when from and to node are missing', async () => {
+      const xTransferDto: XTransferDto = {
+        amount,
+        address,
+        currency,
+      };
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(createApiInstanceSpy).not.toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for missing currency in parachain to parachain transfer', async () => {
+      const xTransferDto: XTransferDto = {
+        from: 'Acala',
+        to: 'Basilisk',
+        amount,
+        address,
+      };
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(createApiInstanceSpy).not.toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for invalid currency', async () => {
+      const xTransferDto: XTransferDto = {
+        from: 'Acala',
+        to: 'Basilisk',
+        amount,
+        address,
+        currency: 'UNKNOWN',
+      };
+
+      const builderMock = {
+        from: jest.fn().mockReturnThis(),
+        to: jest.fn().mockReturnThis(),
+        currency: jest.fn().mockReturnThis(),
+        amount: jest.fn().mockReturnThis(),
+        address: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest.fn().mockImplementation(() => {
+          throw new InvalidCurrencyError('');
+        }),
+      };
+      jest.spyOn(paraspellSdk, 'Builder').mockReturnValue(builderMock as any);
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(createApiInstanceSpy).toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerError when uknown error occures in the SDK', async () => {
+      const xTransferDto: XTransferDto = {
+        from: 'Acala',
+        to: 'Basilisk',
+        amount,
+        address,
+        currency,
+      };
+
+      const builderMock = {
+        from: jest.fn().mockReturnThis(),
+        to: jest.fn().mockReturnThis(),
+        currency: jest.fn().mockReturnThis(),
+        amount: jest.fn().mockReturnThis(),
+        address: jest.fn().mockReturnThis(),
+        buildSerializedApiCall: jest.fn().mockImplementation(() => {
+          throw new Error('Unknown error');
+        }),
+      };
+      jest.spyOn(paraspellSdk, 'Builder').mockReturnValue(builderMock as any);
+
+      await expect(service.generateXcmCall(xTransferDto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(createApiInstanceSpy).toHaveBeenCalled();
+      expect(findWsUrlByNodeSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/src/x-transfer/x-transfer.service.ts
+++ b/src/x-transfer/x-transfer.service.ts
@@ -10,17 +10,13 @@ import {
   NODE_NAMES,
   TNode,
   TSerializedApiCall,
-  getRelayChainSymbol,
 } from '@paraspell/sdk';
 import { XTransferDto } from './dto/XTransferDto';
-import { createApiInstance, findWsUrlByNode } from 'src/utils';
-
-const getNodeRelayChainWsUrl = (destinationNode: TNode) => {
-  const symbol = getRelayChainSymbol(destinationNode);
-  const POLKADOT_WS = 'wss://kusama-rpc.polkadot.io';
-  const KUSAMA_WS = 'wss://rpc.polkadot.io';
-  return symbol === 'DOT' ? POLKADOT_WS : KUSAMA_WS;
-};
+import {
+  createApiInstance,
+  findWsUrlByNode,
+  getNodeRelayChainWsUrl,
+} from 'src/utils';
 
 const determineWsUrl = (fromNode?: TNode, destinationNode?: TNode) => {
   return fromNode


### PR DESCRIPTION
## PR Description: Adding Unit Tests for Service and Controller Functions

This pull request focuses on enhancing the reliability and maintainability of our Polkadot XCM API project, known as LightSpell⚡️. Previously, there were no unit tests for the service functions and controller functions in our Nest.JS application. With this PR, we introduce a comprehensive suite of unit tests to ensure the correctness of these critical components.

### Changes Overview:

- **.github/workflows/ci.yml**: Added a GitHub Actions workflow to automate continuous integration. This workflow checks out the code, sets up the necessary environment, and performs tasks such as enabling corepack, setting up Node.js, installing dependencies, building the project, checking formatting, linting, and running tests.

- **src/assets**: Various changes:
  - **assets.controller.spec.ts**: Included integration tests for the assets controller and assets service, ensuring they work together as expected.
  - **assets.service.spec.ts**: Introduced unit tests for the assets service, ensuring its correctness and reliability.

- **src/channels**: Incorporated tests for the channels module and service:
  - **channels.controller.spec.ts**: Included integration tests for the channels controller and channels service, ensuring they work together as expected.
  - **channels.service.spec.ts**: Added unit tests for the channels service.

- **src/pallets**: Enhanced testing for the pallets module and service:
  - **pallets.controller.spec.ts**: Included integration tests for the pallets controller and pallets service, ensuring they work together as expected.
  - **pallets.service.spec.ts**: Included unit tests for the pallets service.

- **src/utils.spec.ts**: Refactored utility functions and applied corresponding tests for validation.

- **src/x-transfer**: Made modifications to the x-transfer module and service:
  - **x-transfer/x-transfer.controller.spec.ts**: Included integration tests for the x-transfer controller and x-transfer service, ensuring they work together as expected.
  - **x-transfer/x-transfer.service.spec.ts**: Introduced unit tests for the x-transfer service.

