### PR TITLE
Add End-To-End tests using supertest

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.js', 'test/app.e2e-spec.ts'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
       - run: pnpm lint
       - run: pnpm build
       - run: pnpm test
+      - run: pnpm test:e2e
       - uses: codecov/codecov-action@v3

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json --forceExit",
+    "test:e2e:watch": "jest --watch --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -8,15 +7,14 @@ describe('AppController', () => {
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
     }).compile();
 
     appController = app.get<AppController>(AppController);
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return undefined because it redirects to XCM API Github repo"', () => {
+      expect(appController.root()).toBeUndefined();
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,9 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Get, Redirect } from '@nestjs/common';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
-
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
+  @Redirect('https://github.com/paraspell/xcm-api', 301)
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  root() {}
 }

--- a/src/app.module.spec.ts
+++ b/src/app.module.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from './app.module';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { XTransferModule } from './x-transfer/x-transfer.module';
 import { AssetsModule } from './assets/assets.module';
 import { ChannelsModule } from './channels/channels.module';
@@ -23,11 +22,6 @@ describe('AppModule', () => {
   it('should have the correct controllers', () => {
     const controllers = appModule.get<AppController>(AppController);
     expect(controllers).toBeDefined();
-  });
-
-  it('should have the correct providers', () => {
-    const providers = appModule.get<AppService>(AppService);
-    expect(providers).toBeDefined();
   });
 
   it('should have the correct module imports', () => {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 import { XTransferModule } from './x-transfer/x-transfer.module';
 import { AssetsModule } from './assets/assets.module';
 import { ChannelsModule } from './channels/channels.module';
@@ -9,6 +8,5 @@ import { PalletsModule } from './pallets/pallets.module';
 @Module({
   imports: [XTransferModule, AssetsModule, ChannelsModule, PalletsModule],
   controllers: [AppController],
-  providers: [AppService],
 })
 export class AppModule {}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class AppService {
-  getHello(): string {
-    return 'Hello World!';
-  }
-}

--- a/src/assets/assets.controller.spec.ts
+++ b/src/assets/assets.controller.spec.ts
@@ -92,7 +92,7 @@ describe('AssetsController', () => {
       const mockResult = '1';
       jest.spyOn(assetsService, 'getAssetId').mockReturnValue(mockResult);
 
-      const result = controller.getAssetId(node, symbol);
+      const result = controller.getAssetId(node, { symbol });
 
       expect(result).toBe(mockResult);
       expect(assetsService.getAssetId).toHaveBeenCalledWith(node, symbol);
@@ -156,7 +156,7 @@ describe('AssetsController', () => {
       const mockResult = 18;
       jest.spyOn(assetsService, 'getDecimals').mockReturnValue(mockResult);
 
-      const result = controller.getDecimals(node, symbol);
+      const result = controller.getDecimals(node, { symbol });
 
       expect(result).toBe(mockResult);
       expect(assetsService.getDecimals).toHaveBeenCalledWith(node, symbol);
@@ -170,7 +170,7 @@ describe('AssetsController', () => {
         .spyOn(assetsService, 'hasSupportForAsset')
         .mockReturnValue(mockResult);
 
-      const result = controller.hasSupportForAsset(node, symbol);
+      const result = controller.hasSupportForAsset(node, { symbol });
 
       expect(result).toBe(mockResult);
       expect(assetsService.hasSupportForAsset).toHaveBeenCalledWith(

--- a/src/assets/assets.controller.ts
+++ b/src/assets/assets.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { AssetsService } from './assets.service';
-import { isNumeric } from 'src/utils';
+import { isNumeric } from '../utils';
+import { SymbolDto } from './dto/SymbolDto';
 
 @Controller('assets')
 export class AssetsController {
@@ -20,8 +21,8 @@ export class AssetsController {
     return this.assetsService.getAssetsObject(nodeOrParaId);
   }
 
-  @Get(':node/id/:symbol')
-  getAssetId(@Param('node') node: string, @Param('symbol') symbol: string) {
+  @Get(':node/id')
+  getAssetId(@Param('node') node: string, @Query() { symbol }: SymbolDto) {
     return this.assetsService.getAssetId(node, symbol);
   }
 
@@ -45,15 +46,15 @@ export class AssetsController {
     return this.assetsService.getAllAssetsSymbols(node);
   }
 
-  @Get(':node/decimals/:symbol')
-  getDecimals(@Param('node') node: string, @Param('symbol') symbol: string) {
+  @Get(':node/decimals')
+  getDecimals(@Param('node') node: string, @Query() { symbol }: SymbolDto) {
     return this.assetsService.getDecimals(node, symbol);
   }
 
-  @Get(':node/has-support/:symbol')
+  @Get(':node/has-support')
   hasSupportForAsset(
     @Param('node') node: string,
-    @Param('symbol') symbol: string,
+    @Query() { symbol }: SymbolDto,
   ) {
     return this.assetsService.hasSupportForAsset(node, symbol);
   }

--- a/src/assets/assets.service.ts
+++ b/src/assets/assets.service.ts
@@ -13,7 +13,7 @@ import {
   getTNode,
   hasSupportForAsset,
 } from '@paraspell/sdk';
-import { validateNode } from 'src/utils';
+import { validateNode } from '../utils';
 
 @Injectable()
 export class AssetsService {
@@ -58,7 +58,7 @@ export class AssetsService {
   getDecimals(node: string, symbol: string) {
     validateNode(node);
     const decimals = getAssetDecimals(node as TNode, symbol);
-    if (!decimals) {
+    if (decimals === null) {
       throw new NotFoundException(`Decimals for currency ${symbol} not found.`);
     }
     return decimals;

--- a/src/assets/dto/SymbolDto.ts
+++ b/src/assets/dto/SymbolDto.ts
@@ -1,0 +1,6 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class SymbolDto {
+  @IsNotEmpty()
+  symbol: string;
+}

--- a/src/pallets/pallets.service.ts
+++ b/src/pallets/pallets.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { TNode, getDefaultPallet, getSupportedPallets } from '@paraspell/sdk';
-import { validateNode } from 'src/utils';
+import { validateNode } from '../utils';
 
 @Injectable()
 export class PalletsService {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,3 +44,9 @@ export const getNodeRelayChainWsUrl = (destinationNode: TNode) => {
   const KUSAMA_WS = 'wss://rpc.polkadot.io';
   return symbol === 'DOT' ? POLKADOT_WS : KUSAMA_WS;
 };
+
+export const determineWsUrl = (fromNode?: TNode, destinationNode?: TNode) => {
+  return fromNode
+    ? findWsUrlByNode(fromNode)
+    : getNodeRelayChainWsUrl(destinationNode);
+};

--- a/src/x-transfer/x-transfer.service.ts
+++ b/src/x-transfer/x-transfer.service.ts
@@ -12,17 +12,7 @@ import {
   TSerializedApiCall,
 } from '@paraspell/sdk';
 import { XTransferDto } from './dto/XTransferDto';
-import {
-  createApiInstance,
-  findWsUrlByNode,
-  getNodeRelayChainWsUrl,
-} from 'src/utils';
-
-const determineWsUrl = (fromNode?: TNode, destinationNode?: TNode) => {
-  return fromNode
-    ? findWsUrlByNode(fromNode)
-    : getNodeRelayChainWsUrl(destinationNode);
-};
+import { createApiInstance, determineWsUrl } from '../utils';
 
 @Injectable()
 export class XTransferService {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,9 +2,28 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
+import {
+  Builder,
+  NODE_NAMES,
+  TNode,
+  getAllAssetsSymbols,
+  getAssetsObject,
+  getDefaultPallet,
+  getNativeAssets,
+  getOtherAssets,
+  getParaId,
+  getRelayChainSymbol,
+  getSupportedPallets,
+  hasSupportForAsset,
+} from '@paraspell/sdk';
+import { ApiPromise } from '@polkadot/api';
+import { createApiInstance, determineWsUrl } from '../src/utils';
 
-describe('AppController (e2e)', () => {
+describe('XCM API (e2e)', () => {
   let app: INestApplication;
+  const mockNode: TNode = 'Basilisk';
+  const mockSymbol = 'DOT';
+  const unknownNode = 'UnknownNode';
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,10 +34,439 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+  describe('Pallets controller', () => {
+    NODE_NAMES.forEach((node) => {
+      const supoortedPalletsUrl = `/pallets/${node}`;
+      it(`Supported pallets - ${supoortedPalletsUrl} (GET)`, () => {
+        const pallets = getSupportedPallets(node);
+        return request(app.getHttpServer())
+          .get(supoortedPalletsUrl)
+          .expect(200)
+          .expect(pallets);
+      });
+
+      const defaultPalletUrl = `/pallets/${node}/default`;
+      it(`Default pallet - ${defaultPalletUrl} (GET)`, () => {
+        const pallet = getDefaultPallet(node);
+        return request(app.getHttpServer())
+          .get(defaultPalletUrl)
+          .expect(200)
+          .expect(JSON.stringify(pallet));
+      });
+    });
+
+    const supportedPalletsUnknownNodeUrl = `/pallets/${unknownNode}`;
+    it(`Supported pallets - ${supportedPalletsUnknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(supportedPalletsUnknownNodeUrl)
+        .expect(400);
+    });
+
+    const defaultPalletUnknownNodeUrl = `/pallets/${unknownNode}/default`;
+    it(`Default pallet - ${defaultPalletUnknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(defaultPalletUnknownNodeUrl)
+        .expect(400);
+    });
+  });
+
+  describe('Channels controller', () => {
+    const maxSize = '8';
+    const maxMessageSize = '1024';
+    const inbound = '0';
+    const outbound = '0';
+
+    const channelsUrl = '/hrmp/channels';
+
+    NODE_NAMES.forEach((node) => {
+      it(`Open channel ${node} -> ${mockNode} - ${channelsUrl} (POST)`, () => {
+        const serializedApiCall = Builder(null as unknown as ApiPromise)
+          .from(node)
+          .to(mockNode)
+          .openChannel()
+          .maxSize(Number(maxSize))
+          .maxMessageSize(Number(maxMessageSize))
+          .buildSerializedApiCall();
+
+        return request(app.getHttpServer())
+          .post(channelsUrl)
+          .query({
+            from: node,
+            to: mockNode,
+            maxSize,
+            maxMessageSize,
+          })
+          .expect(201)
+          .expect(serializedApiCall);
+      });
+
+      it(`Open channel ${mockNode} -> ${node} - ${channelsUrl} (POST)`, () => {
+        const serializedApiCall = Builder(null as unknown as ApiPromise)
+          .from(node)
+          .to(mockNode)
+          .openChannel()
+          .maxSize(Number(maxSize))
+          .maxMessageSize(Number(maxMessageSize))
+          .buildSerializedApiCall();
+
+        return request(app.getHttpServer())
+          .post(channelsUrl)
+          .query({
+            from: node,
+            to: mockNode,
+            maxSize,
+            maxMessageSize,
+          })
+          .expect(201)
+          .expect(serializedApiCall);
+      });
+
+      it(`Close channel ${node} - ${channelsUrl} (DELETE)`, () => {
+        const serializedApiCall = Builder(null as unknown as ApiPromise)
+          .from(node)
+          .closeChannel()
+          .inbound(Number(inbound))
+          .outbound(Number(outbound))
+          .buildSerializedApiCall();
+
+        return request(app.getHttpServer())
+          .delete(channelsUrl)
+          .query({
+            from: node,
+            inbound,
+            outbound,
+          })
+          .expect(200)
+          .expect(serializedApiCall);
+      });
+    });
+
+    it(`Open channel - ${unknownNode} from - ${channelsUrl} (POST)`, () => {
+      return request(app.getHttpServer())
+        .post(channelsUrl)
+        .query({
+          from: unknownNode,
+          to: mockNode,
+          maxSize,
+          maxMessageSize,
+        })
+        .expect(400);
+    });
+
+    it(`Open channel - ${unknownNode} to - ${channelsUrl} (POST)`, () => {
+      return request(app.getHttpServer())
+        .post(channelsUrl)
+        .query({
+          from: mockNode,
+          to: unknownNode,
+          maxSize,
+          maxMessageSize,
+        })
+        .expect(400);
+    });
+
+    it(`Close channel - ${unknownNode} - ${channelsUrl} (DELETE)`, () => {
+      return request(app.getHttpServer())
+        .delete(channelsUrl)
+        .query({
+          from: unknownNode,
+          inbound,
+          outbound,
+        })
+        .expect(400);
+    });
+  });
+
+  describe('Assets controller', () => {
+    const unknownSymbol = 'UnknownSymbol';
+
+    const nodeNamesUrl = '/assets';
+    it(`Get node names - ${nodeNamesUrl} (GFT)`, () => {
+      return request(app.getHttpServer())
+        .get(nodeNamesUrl)
+        .expect(200)
+        .expect(NODE_NAMES);
+    });
+
+    NODE_NAMES.forEach((node) => {
+      const assetsObjectUrl = `/assets/${node}`;
+      it(`Get assets object - ${assetsObjectUrl} (GFT)`, () => {
+        const assetsObject = getAssetsObject(node);
+        return request(app.getHttpServer())
+          .get(assetsObjectUrl)
+          .expect(200)
+          .expect(assetsObject);
+      });
+
+      const otherAssets = getOtherAssets(node);
+      if (otherAssets.length > 0) {
+        const { symbol, assetId, decimals } = otherAssets[0];
+        const assetIdUrl = `/assets/${node}/id`;
+        it(`Get asset id - ${assetIdUrl} (GET)`, () => {
+          return request(app.getHttpServer())
+            .get(assetIdUrl)
+            .query({ symbol })
+            .expect(200)
+            .expect(assetId);
+        });
+
+        const assetDecimalsUrl = `/assets/${node}/decimals`;
+        it(`Get asset decimals - ${assetDecimalsUrl} symbol=${symbol} (GET)`, () => {
+          return request(app.getHttpServer())
+            .get(assetDecimalsUrl)
+            .query({ symbol })
+            .expect(200)
+            .expect((res) => expect(Number(res.text)).toEqual(decimals));
+        });
+
+        const hasSupportUrl = `/assets/${node}/has-support`;
+        it(`Has support for asset - ${hasSupportUrl} (GET)`, () => {
+          const hasSupport = hasSupportForAsset(node, symbol);
+          return request(app.getHttpServer())
+            .get(hasSupportUrl)
+            .query({ symbol })
+            .expect(200)
+            .expect((res) => expect(Boolean(res.text)).toEqual(hasSupport));
+        });
+      }
+
+      const relayChainSymbolUrl = `/assets/${node}/relay-chain-symbol`;
+      it(`Get relaychain symbol - ${relayChainSymbolUrl} (GET)`, () => {
+        const relayChainSymbol = getRelayChainSymbol(node);
+        return request(app.getHttpServer())
+          .get(relayChainSymbolUrl)
+          .expect(200)
+          .expect(JSON.stringify(relayChainSymbol));
+      });
+
+      const nativeAssetsUrl = `/assets/${node}/native`;
+      it(`Get native assets - ${nativeAssetsUrl} (GFT)`, () => {
+        const nativeAssets = getNativeAssets(node);
+        return request(app.getHttpServer())
+          .get(nativeAssetsUrl)
+          .expect(200)
+          .expect(nativeAssets);
+      });
+
+      const otherAssetsUrl = `/assets/${node}/other`;
+      it(`Get other assets - ${otherAssetsUrl} (GFT)`, () => {
+        const otherAssets = getOtherAssets(node);
+        return request(app.getHttpServer())
+          .get(otherAssetsUrl)
+          .expect(200)
+          .expect(otherAssets);
+      });
+
+      const allAssetsSymbolsUrl = `/assets/${node}/all-symbols`;
+      it(`Get all assets symbols - ${allAssetsSymbolsUrl} (GET)`, () => {
+        const symbols = getAllAssetsSymbols(node);
+        return request(app.getHttpServer())
+          .get(allAssetsSymbolsUrl)
+          .expect(200)
+          .expect(symbols);
+      });
+
+      const parachainIdUrl = `/assets/${node}/para-id`;
+      it(`Get parachain id - ${parachainIdUrl} (GET)`, () => {
+        const paraId = getParaId(node);
+        return request(app.getHttpServer())
+          .get(parachainIdUrl)
+          .expect(200)
+          .expect((res) => expect(Number(res.text)).toEqual(paraId));
+      });
+    });
+
+    const assetsObjectUknownNodeUrl = `/assets/${unknownNode}`;
+    it(`Get assets object - ${assetsObjectUknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(assetsObjectUknownNodeUrl)
+        .expect(400);
+    });
+
+    const assetIdUknownNodeUrl = `/assets/${unknownNode}/id`;
+    it(`Get asset id - ${assetIdUknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(assetIdUknownNodeUrl)
+        .query({ symbol: mockSymbol })
+        .expect(400);
+    });
+
+    const assetIdUnknownSymbolUrl = `/assets/${mockNode}/id`;
+    it(`Get asset id - non existent symbol - ${assetIdUnknownSymbolUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(assetIdUnknownSymbolUrl)
+        .query({ symbol: unknownSymbol })
+        .expect(404);
+    });
+
+    const relayChainSymbolUknownNodeUrl = `/assets/${unknownNode}/relay-chain-symbol`;
+    it(`Get relaychain symbol - ${relayChainSymbolUknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(relayChainSymbolUknownNodeUrl)
+        .expect(400);
+    });
+
+    const assetDecimalsUknownNodeUrl = `/assets/${unknownNode}/decimals`;
+    it(`Get asset decimals - ${assetDecimalsUknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(assetDecimalsUknownNodeUrl)
+        .query({ symbol: mockSymbol })
+        .expect(400);
+    });
+
+    const assetDecimalsUnknownSymbolUrl = `/assets/${mockNode}/decimals`;
+    it(`Get asset decimals - non existent symbol - ${assetDecimalsUnknownSymbolUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(assetDecimalsUnknownSymbolUrl)
+        .query({ symbol: 'UknownSymbol' })
+        .expect(404);
+    });
+
+    const hasSupportUnknownNodeUrl = `/assets/${unknownNode}/has-support`;
+    it(`Has support for asset - ${hasSupportUnknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(hasSupportUnknownNodeUrl)
+        .query({ symbol: mockSymbol })
+        .expect(400);
+    });
+
+    const parachainIdUnknownNodeUrl = `/assets/${unknownNode}/para-id `;
+    it(`Get parachain id - ${parachainIdUnknownNodeUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(parachainIdUnknownNodeUrl)
+        .expect(400);
+    });
+  });
+
+  describe('X-Transfer controller', () => {
+    const amount = '1000000000';
+    const address = 'FagnR7YW9N2PZfxC3dwSqQjb59Jsz3x35UZ24MqtA4eTVZR';
+    const xTransferUrl = '/x-transfer';
+
+    it(`Generate XCM call - No from or to provided - ${xTransferUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          amount,
+          address,
+        })
+        .expect(400);
+    });
+
+    it(`Generate XCM call - Invalid from - ${xTransferUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          from: unknownNode,
+          amount,
+          address,
+        })
+        .expect(400);
+    });
+
+    it(`Generate XCM call - Invalid to - ${xTransferUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          to: unknownNode,
+          amount,
+          address,
+        })
+        .expect(400);
+    });
+
+    it(`Generate XCM call - Parachain to parachain missing currency - ${xTransferUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          from: 'Acala',
+          to: 'Basilisk',
+          amount,
+          address,
+        })
+        .expect(400);
+    });
+
+    it(`Generate XCM call - Parachain to parachain invalid currency - ${xTransferUrl} (GET)`, () => {
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          from: 'Acala',
+          to: 'Basilisk',
+          amount,
+          address,
+          currency: 'UknownSymbol',
+        })
+        .expect(400);
+    });
+
+    it(`Generate XCM call - Parachain to parachain all valid - ${xTransferUrl} (GET)`, async () => {
+      const from: TNode = 'Statemine';
+      const to: TNode = 'Basilisk';
+      const currency = 'KSM';
+      const wsUrl = determineWsUrl(from, to);
+      const api = await createApiInstance(wsUrl);
+      const serializedApiCall = Builder(api)
+        .from(from)
+        .to(to)
+        .currency(currency)
+        .amount(amount)
+        .address(address)
+        .buildSerializedApiCall();
+      await api.disconnect();
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          from,
+          to,
+          amount,
+          address,
+          currency,
+        })
+        .expect(200)
+        .expect(serializedApiCall);
+    });
+
+    it(`Generate XCM call - Parachain to relaychain all valid - ${xTransferUrl} (GET)`, async () => {
+      const from: TNode = 'Statemine';
+      const wsUrl = determineWsUrl(from);
+      const api = await createApiInstance(wsUrl);
+      const serializedApiCall = Builder(api)
+        .from(from)
+        .amount(amount)
+        .address(address)
+        .buildSerializedApiCall();
+      await api.disconnect();
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          from,
+          amount,
+          address,
+        })
+        .expect(200)
+        .expect(serializedApiCall);
+    });
+
+    it(`Generate XCM call - Relaychain to parachain all valid - ${xTransferUrl} (GET)`, async () => {
+      const to: TNode = 'Statemine';
+      const wsUrl = determineWsUrl(undefined, to);
+      const api = await createApiInstance(wsUrl);
+      const serializedApiCall = Builder(api)
+        .to(to)
+        .amount(amount)
+        .address(address)
+        .buildSerializedApiCall();
+      await api.disconnect();
+      return request(app.getHttpServer())
+        .get(xTransferUrl)
+        .query({
+          to,
+          amount,
+          address,
+        })
+        .expect(200)
+        .expect(serializedApiCall);
+    });
   });
 });


### PR DESCRIPTION
**PR Description: Adding End-to-End Tests for Comprehensive API Coverage**

This pull request introduces a robust suite of end-to-end tests to comprehensively cover the functionality of our Polkadot XCM API, named LightSpell⚡️. These tests validate the interactions between different components of the API and ensure its correctness in real-world scenarios. By adding these end-to-end tests, we enhance the reliability and confidence in our application.

**End-to-End Tests:** A new set of end-to-end tests has been added using the `supertest` library to simulate HTTP requests and interactions with our API. These tests encompass the following controllers and their respective routes:

- **Pallets Controller Tests:** The tests cover various scenarios of retrieving supported pallets and default pallets for different nodes. They also verify error handling for unknown nodes.

- **Channels Controller Tests:** These tests include opening and closing HRMP channels between nodes. They also validate the handling of different scenarios, including valid and invalid nodes.

- **Assets Controller Tests:** The tests encompass a wide range of asset-related queries, such as retrieving asset objects, IDs, decimals, support checks, relay chain symbols, native assets, and more. They also validate the behavior for unknown nodes and symbols.

- **X-Transfer Controller Tests:** These tests simulate the generation of XCM calls for different scenarios, including Parachain to Parachain, Parachain to Relaychain, and Relaychain to Parachain transfers. They cover cases where certain parameters are missing or invalid.

EDIT:
This PR also fixes 3 asset endpoints and they now take query parameters.
This is due to fact, that there are currencies containing `/` in their symbols and that caused issues.