### PR TITLE
Fix memory leak by closing socket connection after done

### DIFF
--- a/src/x-transfer/x-transfer.service.spec.ts
+++ b/src/x-transfer/x-transfer.service.spec.ts
@@ -31,7 +31,7 @@ describe('XTransferService', () => {
     service = module.get<XTransferService>(XTransferService);
     createApiInstanceSpy = jest
       .spyOn(utils, 'createApiInstance')
-      .mockResolvedValue({} as any);
+      .mockResolvedValue(null as any);
     findWsUrlByNodeSpy = jest.spyOn(utils, 'findWsUrlByNode');
     getNodeRelayChainWsUrlSpy = jest.spyOn(utils, 'getNodeRelayChainWsUrl');
   });

--- a/src/x-transfer/x-transfer.service.ts
+++ b/src/x-transfer/x-transfer.service.ts
@@ -71,6 +71,8 @@ export class XTransferService {
         throw new BadRequestException(e.message);
       }
       throw new InternalServerErrorException(e.message);
+    } finally {
+      if (api) api.disconnect();
     }
     return response;
   }


### PR DESCRIPTION
This PR addresses a memory leak issue in the XTransferService by ensuring that the Polkadot JS API promise is closed correctly after an HTTP request is completed.